### PR TITLE
Check backends; don't route to non-working ones

### DIFF
--- a/hamba
+++ b/hamba
@@ -40,7 +40,7 @@ EOF
 # Now generate all the backend entries.
 shift
 while [ "$1" ]; do
-    echo "  server $1-$2 $1:$2 maxconn 32 "
+    echo "  server $1-$2 $1:$2 maxconn 32 check "
     shift
     shift
 done


### PR DESCRIPTION
By default, `hamba` will route to backends if they are not running.

For example if I have something like:

```
$ docker-compose ps
      Name                    Command               State                     Ports
-----------------------------------------------------------------------------------------------------
whale_anonweb0_1   hamba 8000 anonweb1 8000 a ...   Up       0.0.0.0:32805->8000/tcp
whale_anonweb1_1   /run.sh gunicorn --paste=d ...   Up       0.0.0.0:32802->8000/tcp
whale_anonweb2_1   /run.sh gunicorn --paste=d ...   Exit 2
whale_anonweb3_1   /run.sh gunicorn --paste=d ...   Exit 2
```

where the hamba container routes to 3 backends and then I stop 2 out of the 3 backends (with `docker-compose stop anonweb2 anonweb3`), I get a lot of gateway errors when hitting hamba, because it does round-robin and routes even to unhealthy backends.

With my change, haproxy knows not to route to the containers that aren't running.

Cc: @sudarkoff
